### PR TITLE
Bump Hypriot's docker build to fix #2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get install $(apt-cache depends docker.io | grep Depends | sed "s/.*ends
 
 
 # Install Docker
-ENV DOCKER_VERSION=1.9.0 DOCKER_FIX=-1
+ENV DOCKER_VERSION=1.9.0 DOCKER_FIX=-2
 # docker-hypriot_XXX_armhf.deb built using https://github.com/hypriot/rpi-docker-builder
 RUN wget -q http://downloads.hypriot.com/docker-hypriot_${DOCKER_VERSION}${DOCKER_FIX}_armhf.deb -O /tmp/docker.deb \
  && dpkg -i /tmp/docker.deb \


### PR DESCRIPTION
Which change the default systemd init script (s/-d/daemon/)