### PR TITLE
Set `docker daemon` MTU to 1500,

### DIFF
--- a/overlay/etc/default/docker
+++ b/overlay/etc/default/docker
@@ -2,4 +2,5 @@ DOCKER_OPTS='                   \
 -H unix:///var/run/docker.sock  \
 --storage-driver aufs           \
 --label provider=scaleway       \
+--mtu=1500                      \
 '


### PR DESCRIPTION
It fixes PMTU discovery issues when running inside Docker;
Fixes docker-in-docker based builds.

Addresses docker/docker#18176