### PR TITLE
Bump to 17.03

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,7 @@ RUN sed -i '/mirror.scaleway/s/^/#/' /etc/apt/sources.list \
 
 # Install Docker
 RUN case "${ARCH}" in                                                                                 \
-    armv7l|armhf|arm)                                                                                 \
-      curl -Ls https://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_17.03.0~ce-0~debian-jessie_armhf.deb > docker.deb && \
-      dpkg -i docker.deb &&                                                                           \
-      rm docker.deb;                                                                                  \
-      ;;                                                                                              \
-    amd64|x86_64|i386)                                                                                \
+    amd64|x86_64|i386|armv7l|armhf|arm)                                                               \
       curl -L https://get.docker.com/ | sh;                                                           \
       ;;                                                                                              \
     *)                                                                                                \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN sed -i '/mirror.scaleway/s/^/#/' /etc/apt/sources.list \
 # Install Docker
 RUN case "${ARCH}" in                                                                                 \
     armv7l|armhf|arm)                                                                                 \
-      curl -Ls https://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.12.2-0~jessie_armhf.deb > docker.deb && \
+      curl -Ls https://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_17.03.0~ce-0~debian-jessie_armhf.deb > docker.deb && \
       dpkg -i docker.deb &&                                                                           \
       rm docker.deb;                                                                                  \
       ;;                                                                                              \


### PR DESCRIPTION
Bump version to 17.03 and forever beyond as ARM is now supported in the get.docker.com script