### PR TITLE
Add an arm64 version of this image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,20 +36,7 @@ RUN sed -i '/mirror.scaleway/s/^/#/' /etc/apt/sources.list \
 
 
 # Install Docker
-RUN case "${ARCH}" in                                                                                 \
-    armv7l|armhf|arm)                                                                                 \
-      curl -Ls https://apt.dockerproject.org/repo/pool/main/d/docker-engine/docker-engine_1.12.2-0~jessie_armhf.deb > docker.deb && \
-      dpkg -i docker.deb &&                                                                           \
-      rm docker.deb;                                                                                  \
-      ;;                                                                                              \
-    amd64|x86_64|i386)                                                                                \
-      curl -L https://get.docker.com/ | sh;                                                           \
-      ;;                                                                                              \
-    *)                                                                                                \
-      echo "Unhandled architecture: ${ARCH}."; exit 1;                                                \
-      ;;                                                                                              \
-    esac                                                                                              \
- && docker --version
+RUN apt-get install -y docker.io && docker --version
 
 
 # Install Pipework
@@ -79,12 +66,8 @@ RUN case "${ARCH}" in                                                           
  && ( gosu --version || true )
 
 
-
 # Install Docker Compose
-RUN easy_install -U pip                                     \
- && pip install docker-compose                              \
- && ln -s /usr/local/bin/docker-compose /usr/local/bin/fig  \
- && docker-compose --version
+RUN apt-get install -y docker-compose && docker-compose --version
 
 
 # Install Docker Machine

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,9 @@ RUN case "${ARCH}" in                                                           
         ;;                                                                                                                                                          \
     esac;                                                                                                                                                           \
     MACHINE_REPO=https://api.github.com/repos/docker/machine/releases/latest                                                                                        \
-    MACHINE_URL=$(curl -L $MACHINE_REPO | jq -r --arg n "docker-machine-Linux-${arch_docker}" '.assets[] | select(.name | contains($n)) | .url')                       \
+    MACHINE_URL=$(curl -L $MACHINE_REPO | jq -r --arg n "docker-machine-Linux-${arch_docker}" '.assets[] | select(.name | contains($n)) | .browser_download_url')   \
     curl -L $MACHINE_URL >/usr/local/bin/docker-machine &&                                                                                                          \
-    chmod +x /usr/local/bin/docker-machine && docker-machine --version
+    chmod +x /usr/local/bin/docker-machine
 
 
 # Install Pipework

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN /usr/local/sbin/builder-enter
 # Install packages
 RUN sed -i '/mirror.scaleway/s/^/#/' /etc/apt/sources.list \
  && apt-get -q update                   \
- && echo "Y" | apt-get --force-yes -y -qq upgrade  \
- && apt-get --force-yes install -y -q   \
+ && echo "Y" | apt-get upgrade  -y -qq  \
+ && apt-get install -y -q               \
       apparmor                          \
       arping                            \
       aufs-tools                        \
@@ -32,24 +32,12 @@ RUN sed -i '/mirror.scaleway/s/^/#/' /etc/apt/sources.list \
       lxc                               \
       python-setuptools                 \
       vlan                              \
+      gosu                              \
  && apt-get clean
 
 
 # Install Docker
-RUN apt-get install -y docker.io && docker --version
-
-
-# Install Pipework
-RUN wget -qO /usr/local/bin/pipework https://raw.githubusercontent.com/jpetazzo/pipework/master/pipework  \
- && chmod +x /usr/local/bin/pipework
-
-
-# Install Gosu
-RUN apt-get install -y gosu
-
-
-# Install Docker Compose
-RUN apt-get install -y docker-compose && docker-compose --version
+RUN apt-get install -q -y docker.io docker-compose
 
 
 # Install Docker Machine
@@ -70,6 +58,11 @@ RUN case "${ARCH}" in                                                           
     esac;                                                                                                                                                           \
     curl -L https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-${arch_docker} >/usr/local/bin/docker-machine &&    \
     chmod +x /usr/local/bin/docker-machine && docker-machine --version
+
+
+# Install Pipework
+RUN wget -qO /usr/local/bin/pipework https://raw.githubusercontent.com/jpetazzo/pipework/master/pipework  \
+ && chmod +x /usr/local/bin/pipework
 
 
 # Patch rootfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN wget -qO /usr/local/bin/pipework https://raw.githubusercontent.com/jpetazzo/
 
 
 # Install Gosu
-RUN apt-get install -y gosu && gosu --version
+RUN apt-get install -y gosu
 
 
 # Install Docker Compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN case "${ARCH}" in                                                           
         ;;                                                                                                                                                          \
     esac;                                                                                                                                                           \
     MACHINE_REPO=https://api.github.com/repos/docker/machine/releases/latest                                                                                        \
-    MACHINE_URL=$(curl -L $MACHINE_REPO | jq --arg n "docker-machine-Linux-${arch_docker}" '.assets[] | select(.name | contains($n)) | .url')                       \
+    MACHINE_URL=$(curl -L $MACHINE_REPO | jq -r --arg n "docker-machine-Linux-${arch_docker}" '.assets[] | select(.name | contains($n)) | .url')                       \
     curl -L $MACHINE_URL >/usr/local/bin/docker-machine &&                                                                                                          \
     chmod +x /usr/local/bin/docker-machine && docker-machine --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,17 +71,23 @@ RUN apt-get install -y docker-compose && docker-compose --version
 
 
 # Install Docker Machine
-ENV DOCKER_MACHINE_VERSION=0.8.2
-RUN case "${ARCH}" in                                                                                                                                        \
-    x86_64|amd64|i386)                                                                                                                                       \
-        curl -L https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-x86_64 >/usr/local/bin/docker-machine && \
-        chmod +x /usr/local/bin/docker-machine &&                                                                                                            \
-       	docker-machine --version;                                                                                                                            \
-      ;;                                                                                                                                                     \
-    *)                                                                                                                                                       \
-       	echo "docker-machine not yet supported for this architecture."                                                                                       \
-      ;;                                                                                                                                                     \
-    esac
+ENV DOCKER_MACHINE_VERSION=0.11.0
+RUN case "${ARCH}" in                                                                                                                                       \
+    x86_64|amd64|i386)                                                                                                                                      \
+        arch_docker=x86_64;                                                                                                                                 \
+        ;;                                                                                                                                                  \
+    aarch64|arm64)                                                                                                                                          \
+        arch_docker=aarch64;                                                                                                                                \
+        ;;                                                                                                                                                  \
+    armhf|armv7l|arm)                                                                                                                                       \
+        arch_docker=armhf;                                                                                                                                  \
+        ;;                                                                                                                                                  \
+    *)                                                                                                                                                      \
+        echo "docker-machine not yet supported for this architecture."; exit 0;                                                                             \
+        ;;                                                                                                                                                  \
+    esac;                                                                                                                                                   \
+    curl -L https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-x86_64 >/usr/local/bin/docker-machine &&    \
+    chmod +x /usr/local/bin/docker-machine && docker-machine --version
 
 
 # Patch rootfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,24 +41,23 @@ RUN apt-get install -q -y docker.io docker-compose
 
 
 # Install Docker Machine
-RUN case "${ARCH}" in                                                                                                                                               \
-    x86_64|amd64|i386)                                                                                                                                              \
-        arch_docker=x86_64;                                                                                                                                         \
-        ;;                                                                                                                                                          \
-    aarch64|arm64)                                                                                                                                                  \
-        arch_docker=aarch64;                                                                                                                                        \
-        ;;                                                                                                                                                          \
-    armhf|armv7l|arm)                                                                                                                                               \
-        arch_docker=armhf;                                                                                                                                          \
-        ;;                                                                                                                                                          \
-    *)                                                                                                                                                              \
-        echo "docker-machine not yet supported for this architecture."; exit 0;                                                                                     \
-        ;;                                                                                                                                                          \
-    esac;                                                                                                                                                           \
-    MACHINE_REPO=https://api.github.com/repos/docker/machine/releases/latest                                                                                        \
-    MACHINE_URL=$(curl -L $MACHINE_REPO | jq -r --arg n "docker-machine-Linux-${arch_docker}" '.assets[] | select(.name | contains($n)) | .browser_download_url')   \
-    curl -L $MACHINE_URL >/usr/local/bin/docker-machine &&                                                                                                          \
-    chmod +x /usr/local/bin/docker-machine
+RUN case "${ARCH}" in                                                                                                                                                 \
+    x86_64|amd64|i386)                                                                                                                                                \
+        arch_docker=x86_64;                                                                                                                                           \
+        ;;                                                                                                                                                            \
+    aarch64|arm64)                                                                                                                                                    \
+        arch_docker=aarch64;                                                                                                                                          \
+        ;;                                                                                                                                                            \
+    armhf|armv7l|arm)                                                                                                                                                 \
+        arch_docker=armhf;                                                                                                                                            \
+        ;;                                                                                                                                                            \
+    *)                                                                                                                                                                \
+        echo "docker-machine not yet supported for this architecture."; exit 0;                                                                                       \
+        ;;                                                                                                                                                            \
+    esac;                                                                                                                                                             \
+    MACHINE_REPO=https://api.github.com/repos/docker/machine/releases/latest;                                                                                         \
+    MACHINE_URL=$(curl -s -L $MACHINE_REPO | jq -r --arg n "docker-machine-Linux-${arch_docker}" '.assets[] | select(.name | contains($n)) | .browser_download_url'); \
+    curl -s -L $MACHINE_URL >/usr/local/bin/docker-machine && chmod +x /usr/local/bin/docker-machine
 
 
 # Install Pipework
@@ -72,5 +71,5 @@ RUN systemctl disable docker; systemctl enable docker
 
 
 # Clean rootfs from image-builder
-RUN /usr/local/sbin/builder-leave && apt-get remove --auto-remove jq
+RUN /usr/local/sbin/builder-leave && apt-get remove --auto-remove -y jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,25 +45,7 @@ RUN wget -qO /usr/local/bin/pipework https://raw.githubusercontent.com/jpetazzo/
 
 
 # Install Gosu
-ENV GOSU_VERSION=1.10
-RUN case "${ARCH}" in                                                                                                \
-    armv7l|armhf|arm)                                                                                                \
-        wget -qO /usr/local/bin/gosu https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-armhf &&  \
-        chmod +x /usr/local/bin/gosu;                                                                                \
-      ;;                                                                                                             \
-    aarch64|arm64)                                                                                                   \
-        wget -qO /usr/local/bin/gosu https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-arm64 &&  \
-        chmod +x /usr/local/bin/gosu;                                                                                \
-      ;;                                                                                                             \
-    x86_64|amd64)                                                                                                    \
-        wget -qO /usr/local/bin/gosu https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64 &&  \
-        chmod +x /usr/local/bin/gosu;                                                                                \
-       	;;                                                                                                           \
-    *)                                                                                                               \
-       	echo "Unhandled architecture: ${ARCH}."; exit 1;                                                             \
-      ;;                                                                                                             \
-    esac                                                                                                             \
- && ( gosu --version || true )
+RUN apt-get install -y gosu && gosu --version
 
 
 # Install Docker Compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,21 +72,21 @@ RUN apt-get install -y docker-compose && docker-compose --version
 
 # Install Docker Machine
 ENV DOCKER_MACHINE_VERSION=0.11.0
-RUN case "${ARCH}" in                                                                                                                                       \
-    x86_64|amd64|i386)                                                                                                                                      \
-        arch_docker=x86_64;                                                                                                                                 \
-        ;;                                                                                                                                                  \
-    aarch64|arm64)                                                                                                                                          \
-        arch_docker=aarch64;                                                                                                                                \
-        ;;                                                                                                                                                  \
-    armhf|armv7l|arm)                                                                                                                                       \
-        arch_docker=armhf;                                                                                                                                  \
-        ;;                                                                                                                                                  \
-    *)                                                                                                                                                      \
-        echo "docker-machine not yet supported for this architecture."; exit 0;                                                                             \
-        ;;                                                                                                                                                  \
-    esac;                                                                                                                                                   \
-    curl -L https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-x86_64 >/usr/local/bin/docker-machine &&    \
+RUN case "${ARCH}" in                                                                                                                                               \
+    x86_64|amd64|i386)                                                                                                                                              \
+        arch_docker=x86_64;                                                                                                                                         \
+        ;;                                                                                                                                                          \
+    aarch64|arm64)                                                                                                                                                  \
+        arch_docker=aarch64;                                                                                                                                        \
+        ;;                                                                                                                                                          \
+    armhf|armv7l|arm)                                                                                                                                               \
+        arch_docker=armhf;                                                                                                                                          \
+        ;;                                                                                                                                                          \
+    *)                                                                                                                                                              \
+        echo "docker-machine not yet supported for this architecture."; exit 0;                                                                                     \
+        ;;                                                                                                                                                          \
+    esac;                                                                                                                                                           \
+    curl -L https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-Linux-${arch_docker} >/usr/local/bin/docker-machine &&    \
     chmod +x /usr/local/bin/docker-machine && docker-machine --version
 
 


### PR DESCRIPTION
The dockerfile could be simplified as a result of a few packages existing in the Ubuntu repositories:
- docker.io
- docker-compose
- gosu

Because of qemu-aarch64-static not being able to run some go binaries, I removed `docker --version`, `gosu --version` and friends to avoid having the build process crash since we build on Travis and there are no native builders for aarch64 there.